### PR TITLE
fix: Fix backwards quotes

### DIFF
--- a/Naive_Set_Theory_Reedition/main.tex
+++ b/Naive_Set_Theory_Reedition/main.tex
@@ -19,6 +19,8 @@ pagesize=auto]{book}
 \usepackage{lmodern}
 \usepackage{microtype}
 \frenchspacing
+\usepackage{csquotes}
+\MakeOuterQuote{"}
 
 %---- create the axioms enviroment -%
 


### PR DESCRIPTION
**Before:**
<img width="569" alt="Screen Shot 2023-07-16 at 6 34 20 PM" src="https://github.com/matheusgirola/Halmos-Naive-Set-Theory-OCR-LaTeX-Reedition/assets/139499/ae096074-65d8-47cc-b08b-fb7def1ccd9d">

**After:**
<img width="578" alt="Screen Shot 2023-07-16 at 6 34 03 PM" src="https://github.com/matheusgirola/Halmos-Naive-Set-Theory-OCR-LaTeX-Reedition/assets/139499/d9a9d80f-8603-4c73-b056-43da4f2fcc7a">

----

Suggestion taken from https://tex.stackexchange.com/questions/52351/quote-marks-are-backwards-using-texmaker-pdflatex