### PR TITLE
Fix typos editor preface

### DIFF
--- a/Naive_Set_Theory_Reedition/Chapters/Chapter_1.tex
+++ b/Naive_Set_Theory_Reedition/Chapters/Chapter_1.tex
@@ -10,7 +10,7 @@ Sets, as they are usually conceived, have \textit{elements}\index{element} or \t
 The principal concept of set thoery, the one that in completely axiomatic studies is the principal primitive (undefined) concept, is that of \textit{belonging}\index{belonging}. If $x$ belongs to $A$ ($x$ is an element of $A$, $x$ is \textit{contained}\index{contain} in $A$), we shall write 
 
 \begin{equation*}
-x \in A
+x \in A.
 \end{equation*}
 
 This version of the Greek letter epsilon is so often used to denote belonging that its use to denote anything else is almost prohibited. Most authors relegate $\in$ to its set-theoretic use forever and use $\varepsilon$ when they need the fifth letter of the Greek alphabet. 
@@ -27,7 +27,7 @@ A = B;
 the fact that $A$ and $B$ are not equal is expressed by writing 
 
 \begin{equation*}
-A \neq B;
+A \neq B.
 \end{equation*}
 
 The most basic property of belonging is its relation to equality, which can be formulated as follows. 
@@ -37,7 +37,7 @@ The most basic property of belonging is its relation to equality, which can be f
 
 With greater pretentiousness and less clarity: a set is determined by its extension. 
 
-It is valuable to understand that the axiom of extension is not just a logically necessary property of equality but a non-trivial statement about belonging. One way to come to understand the point is to consider a partially analogous situation in which the analogue of the axiom of extension does not hold. Suppose, for instance, that we consider human beings instead of sets, and that, if $x$ and $A$ are human beings, we write $x \in A$ whenever $x$ is an ancestor of $A$. (The ancestors of a human being are his parents, his parents' parents, their parents, etc., etc.) The analogue of the axiiom of extension would say here that if two human beings are equal, then they have the same ancestors (this is the "only if" part, and it is true), and also that if two human being the same ancestors, then they are equal (this is the "if" part, and it is false). 
+It is valuable to understand that the axiom of extension is not just a logically necessary property of equality but a non-trivial statement about belonging. One way to come to understand the point is to consider a partially analogous situation in which the analogue of the axiom of extension does not hold. Suppose, for instance, that we consider human beings instead of sets, and that, if $x$ and $A$ are human beings, we write $x \in A$ whenever $x$ is an ancestor of $A$. (The ancestors of a human being are his parents, his parents' parents, their parents, etc., etc.) The analogue of the axiom of extension would say here that if two human beings are equal, then they have the same ancestors (this is the "only if" part, and it is true), and also that if two human being the same ancestors, then they are equal (this is the "if" part, and it is false). 
 
 If $A$ and $B$ are sets and if every element of $A$ is an element of $B$, we say that $A$ is a \textit{subset}\index{subset} of $B$, or $B$ \textit{includes}\index{inclusion} $A$, and we write 
 
@@ -48,11 +48,11 @@ A \subset B
 or
 
 \begin{equation*}
-A \supset B
+A \supset B.
 \end{equation*}
 
-The wording of the definition implies that each set must be considered to be included in itself ($A \subset A$); this fact is described by saying that set inclusion is \textit{reflexive}\index{reflexive}. (Note that; in the same sense of the word, equality also is reflexive.) If $A$ and $B$ are sets such that $A \subset B$ and $A \neq B$, the word $proper$\index{proper} is used (proper subset, proper inclusion). If $A$, $B$, and $C$ are sets such that $A \subset B$ and $B \subset C$, then $A \subset C$; this fact is described by saying that set inclusion is \textit{transitive}\index{transitive}. (This property is also shared by equality.)
+The wording of the definition implies that each set must be considered to be included in itself ($A \subset A$); this fact is described by saying that set inclusion is \textit{reflexive}\index{reflexive}. (Note that; in the same sense of the word, equality also is reflexive.) If $A$ and $B$ are sets such that $A \subset B$ and $A \neq B$, the word \textit{proper}\index{proper} is used (proper subset, proper inclusion). If $A$, $B$, and $C$ are sets such that $A \subset B$ and $B \subset C$, then $A \subset C$; this fact is described by saying that set inclusion is \textit{transitive}\index{transitive}. (This property is also shared by equality.)
 
 If $A$ and $B$ are sets such that $A \subset B$ and $B \subset A$, then $A$ and $B$ have the same elements and therefore, by the axiom of extension, $A = B$. This fact is described by saying that set inclusion is \textit{antisymmetric}\index{antisymmetric}. (In this respect set inclusion behaves differently from equality. Equality is \textit{symmetric}\index{symmetric}, in the sense that if $A = B$, then necessarily $B = A$.) The axiom of extension can, in fact, be reformulated in these terms: if $A$ and $B$ are sets, then a necessary and sufficient condition that $A = B$ is that both $A \subset B$ and $B \subset A$. Correspondingly , almost all proofs of equalities between two sets $A$ and $B$ are split into two parts; first show that $A \subset B$, and then show that $B \subset A$. 
 
-Observe that belonging ($ \in $) and inclusion ($ \subset$) are conceptually very different indeed. One important difference has already manifested itself above: inclusion is always reflexive, whereas it is at all clear that belonging is ever reflexive. That is: $A \subset A$ is always true; is $A \in A $ ever true? It is certainly not true of any reasonable set that anyone has ever seen. Observe, along the same lines, that inclusion is transitive, whereas belonging is not. Everyday examples, involving, for instance, super-organizations whose members are organizations, will readily occur to the interested reader.
+Observe that belonging ($\in$) and inclusion ($\subset$) are conceptually very different indeed. One important difference has already manifested itself above: inclusion is always reflexive, whereas it is not at all clear that belonging is ever reflexive. That is: $A \subset A$ is always true; is $A \in A $ ever true? It is certainly not true of any reasonable set that anyone has ever seen. Observe, along the same lines, that inclusion is transitive, whereas belonging is not. Everyday examples, involving, for instance, super-organizations whose members are organizations, will readily occur to the interested reader.

--- a/Naive_Set_Theory_Reedition/Chapters/Editor_Preface.tex
+++ b/Naive_Set_Theory_Reedition/Chapters/Editor_Preface.tex
@@ -1,4 +1,4 @@
-As the book title says, this the famous set theory book \textit{Naive Set Theory} by Paul Richard Halmos, first published in 1960 by D. Van Nostrand Company, INC., part of a series called \textit{ The University Series in Undergraduate Mathematics}.
+As the book title says, this is the famous set theory book \textit{Naive Set Theory} by Paul Richard Halmos, first published in 1960 by D. Van Nostrand Company, INC., part of a series called \textit{ The University Series in Undergraduate Mathematics}.
 
 What the title doesn't say is that this version is an independent re-edition. The original work is currently public domain in \href{https://babel.hathitrust.org}{\color{blue}{Hathi Trust Digital Library}} — the reader probably found (or could find) the original digitized book on Google by just searching for its title. This version was written in LaTeX and released on July 14, 2023, available for free to download on my \href{https://github.com/matheusgirola/Halmos-Naive-Set-Theory-OCR-LaTeX-Reedition}{\color{blue}{Github repository}}.
 


### PR DESCRIPTION
In the preface editor in the first sentence and "is" is missing.